### PR TITLE
Do not merge

### DIFF
--- a/perl/bin/crisprReadCounts.pl
+++ b/perl/bin/crisprReadCounts.pl
@@ -54,9 +54,6 @@ sub run {
 
 	my ($plasmid, $plas_name) = get_plasmid_read_counts($options->{'p'});
 
-	# my %genes = %$targeted_genes;
-	# my %plasmid_rc = %$plasmid if($plas_name);
-
 	my ($seen_samp, $samp_name) = get_counts($options->{'i'}, $options->{'r'}, $lib, $trim, $reverse_complementing);
 
 	my %sample = %$seen_samp;
@@ -183,7 +180,6 @@ sub get_counts {
 			$seq_key =~ tr/ACGTacgt/TGCAtgca/;
 		}
 		$lib_seqs{$seq_key} = $seq;
-		# print "seq_key: $seq_key, seq: $seq\n";
 	}
 
 	# assume library sequences are in same length
@@ -197,7 +193,6 @@ sub get_counts {
 		my @data = split /\t/, $tmp;
 		my $cram_seq = $data[9];
 		my $cram_seq_size = length($cram_seq);
-		# print "cram_seq before trim: $cram_seq\n";
 
 		if($data[1] & 16){
 			$cram_seq = reverse($cram_seq);
@@ -210,7 +205,6 @@ sub get_counts {
 			$cram_seq = substr $cram_seq, $trim, $lib_seq_size;
 		}
 
-		# print "cram_seq: $cram_seq\n";
 		my $matching_lib_seq = $lib_seqs{$cram_seq};
 		if ($matching_lib_seq) {
 			foreach my $grna (@{$lib->{$matching_lib_seq}->{'ids'}}) {
@@ -282,5 +276,4 @@ crisprReadCounts.pl [-h] -i /your/input/file.cram -l /your/library/file -p /plas
     --trim                  (-t)   Remove N bases of leading sequence
 
     --reverse-complement    (-rc)  Reverse complementing reads when mapping to guide sequences 
-
 =cut

--- a/perl/bin/crisprReadCounts.pl
+++ b/perl/bin/crisprReadCounts.pl
@@ -38,30 +38,26 @@ use English qw( -no_match_vars );
 use Sanger::CGP::crispr;
 
 {
-  	my $options = option_builder();
+	my $options = option_builder();
 	run($options);
 }
 
 sub run {
 	my ($options) = @_;
 
-	my $plasmid;
-	my $lib_seqs;
-	my $targeted_genes;
-	my $plas_name;
-	my $lib_seq_size;
-	my $trim;
+	# TODO: validate inputs before doing anything
+	my $trim = $options->{'t'};
+	unless($trim) {$trim = 0};
+	my $reverse_complementing = $options->{'rc'};
 
-	$trim = $options->{'t'};
-	($lib_seqs, $targeted_genes, $lib_seq_size) = get_library($options->{'l'});
+	my ($lib, $targeted_genes) = get_library($options->{'l'});
 
-    	($plasmid, $plas_name) = get_plasmid_read_counts($options->{'p'});
+	my ($plasmid, $plas_name) = get_plasmid_read_counts($options->{'p'});
 
-	my %lib = %$lib_seqs;
-	my %genes = %$targeted_genes;
-    	my %plasmid_rc = %$plasmid if($plas_name);
+	# my %genes = %$targeted_genes;
+	# my %plasmid_rc = %$plasmid if($plas_name);
 
-	my ($seen_samp, $samp_name) = get_counts($options->{'i'}, $options->{'r'},$lib_seqs, $trim, $lib_seq_size);
+	my ($seen_samp, $samp_name) = get_counts($options->{'i'}, $options->{'r'}, $lib, $trim, $reverse_complementing);
 
 	my %sample = %$seen_samp;
 
@@ -70,22 +66,22 @@ sub run {
 	if($plas_name){
 		print $OUT "sgRNA\tgene\t".$samp_name.".sample\t".$plas_name."\n";
 
-		foreach my $seq(sort keys %lib){
-			foreach my $grna (@{$lib{$seq}}) {
+		foreach my $seq(sort keys %$lib){
+			foreach my $grna (@{$lib->{$seq}->{'ids'}}) {
 				my $sample_count = $sample{$grna} || 0;
-				my $plasmid_count = $plasmid_rc{$grna} || 0;
-  				print  $OUT "$grna\t$genes{$grna}\t$sample_count\t$plasmid_count\n";
+				my $plasmid_count = $plasmid->{$grna} || 0;
+				print  $OUT "$grna\t" . $targeted_genes->{$grna} . "\t$sample_count\t$plasmid_count\n";
 			}
-  		}
+		}
 	}else{
 		print $OUT "sgRNA\tgene\t".$samp_name.".sample\n";
 
-		foreach my $seq(sort keys %lib){
-			foreach my $grna (@{$lib{$seq}}) {
+		foreach my $seq(sort keys %$lib){
+			foreach my $grna (@{$lib->{$seq}->{'ids'}}) {
 				my $sample_count = $sample{$grna} || 0;
-  				print  $OUT "$grna\t$genes{$grna}\t$sample_count\n";
+				print  $OUT "$grna\t" . $targeted_genes->{$grna} . "\t$sample_count\n";
 			}
-  		}
+		}
 	}
 
 	close $OUT;
@@ -94,30 +90,36 @@ sub run {
 
 sub get_library {
 	my ($lib_file) = @_;
-
-	my %lib_seqs;
+	my %lib;
 	my %targeted_genes;
-	my $lib_seq_size=0;
 
+	my $line_count = 0;
 	if($lib_file){
 		open my $LIB, '<', $lib_file or die 'Failed to open '.$lib_file;
 
- 	 	while(<$LIB>){
-  			my $lib_line = $_;
-  			chomp($lib_line);
-  			my @lib_data = split /\,/, $lib_line;
- 			my $id = $lib_data[0];
+	 	while(<$LIB>){
+			$line_count += 1;
+			my $lib_line = $_;
+			chomp($lib_line);
+			my @lib_data = split /\,/, $lib_line;
+			if (scalar @lib_data < 3) {
+				print "Line: $line_count does not have 3 columns.\n";
+				exit 1;
+			}
+			my $id = $lib_data[0];
 			my $gene = $lib_data[1];
-  			my $lib_seq = $lib_data[2];
-			$lib_seq_size = length($lib_seq);
-  			push(@{$lib_seqs{$lib_seq}}, $id);
+			my $lib_seq = $lib_data[2];
+			if ( $lib_seq !~ /^[ATGCatgc]+$/) {
+				print "Sequence column contains non-DNA characters on line: $line_count.\n";
+				exit 1;
+			}
+			$lib{$lib_seq}->{'length'} = length($lib_seq);
+			push @{$lib{$lib_seq}->{'ids'}}, $id;
 			$targeted_genes{$id} = $gene;
-  		}
-
-  		close $LIB;
+		}
+		close $LIB;
 	}
-
-	return (\%lib_seqs,\%targeted_genes,$lib_seq_size);
+	return (\%lib,\%targeted_genes);
 }
 
 sub get_plasmid_read_counts {
@@ -129,33 +131,32 @@ sub get_plasmid_read_counts {
 	if($plasmid_file){
 		open my $RC, '<', $plasmid_file or die 'Failed to open '.$plasmid_file;
 
- 	 	while(<$RC>){
-  			my $line = $_;
-  			chomp($line);
-  			my @data = split /\t/, $line;
+	 	while(<$RC>){
+			my $line = $_;
+			chomp($line);
+			my @data = split /\t/, $line;
 			unless($line =~ m/^sgRNA\tgene/i){
- 				my $id = $data[0];
+				my $id = $data[0];
 				my $gene = $data[1];
-  				my $count = $data[2];
+				my $count = $data[2];
 				$plasmid{$id} = $count;
 			}else{
 				$plasmid_name = $data[2];
 			}
-  		}
+		}
 
-  		close $RC;
+		close $RC;
 	}
 	return (\%plasmid, $plasmid_name);
 }
 
 sub get_counts {
-  	my ($file, $ref_file, $lib, $trim, $lib_seq_size) = @_;
+	my ($file, $ref_file, $lib, $trim, $reverse_complementing) = @_;
 
+	# get sample name from the cram file
 	my %seen;
 	my $sample_name;
-	my %lib_seqs = %$lib;
-
-	my $head_command = q{samtools view -H -T } .$ref_file . ' ' .$file . q{ | grep -e '^@RG'};
+	my $head_command = q{samtools view -H -T } .$ref_file . ' ' .$file . q{ | grep -e '^@RG' -m 1};
 	my $pid_head = open my $PROC_HEAD, '-|', $head_command or croak "Could not fork: $OS_ERROR";
 	while( my $tmp = <$PROC_HEAD> ) {
 		my @head = split /\t+/, $tmp;
@@ -163,9 +164,30 @@ sub get_counts {
 			if($val =~ m/^SM/i){
 				my($sm, $sample) = split /\:/, $val;
 				$sample_name = $sample;
-				}
+				last;
+			}
 		}
 	}
+
+	unless ($sample_name) {
+		print 'Input CRAM file does not have a "@RG" line in header, or RG lines have no "SM" tag'.".\n";
+		exit 1;
+	}
+
+	my %lib_seqs;
+	foreach my $seq (keys %$lib) {
+		my $seq_key = $seq;
+		if ($reverse_complementing) {
+			# reverse complementing guide RNA sequences instead of each read
+			$seq_key = reverse($seq);
+			$seq_key =~ tr/ACGTacgt/TGCAtgca/;
+		}
+		$lib_seqs{$seq_key} = $seq;
+		# print "seq_key: $seq_key, seq: $seq\n";
+	}
+
+	# assume library sequences are in same length
+	my $lib_seq_size = length((keys %lib_seqs)[0]);
 
 	my $command = 'samtools view -T '. $ref_file . ' ' .$file;
 	my $pid = open my $PROC, '-|', $command or croak "Could not fork: $OS_ERROR";
@@ -175,18 +197,25 @@ sub get_counts {
 		my @data = split /\t/, $tmp;
 		my $cram_seq = $data[9];
 		my $cram_seq_size = length($cram_seq);
+		# print "cram_seq before trim: $cram_seq\n";
 
 		if($data[1] & 16){
 			$cram_seq = reverse($cram_seq);
 			$cram_seq =~ tr/ACGTacgt/TGCAtgca/;
 		}
 
-		if($trim && $trim>0){
+		if($reverse_complementing){
+			$cram_seq = substr $cram_seq, -$trim-$lib_seq_size, $lib_seq_size;
+		} else {
 			$cram_seq = substr $cram_seq, $trim, $lib_seq_size;
 		}
 
-		foreach my $grna (@{$lib_seqs{$cram_seq}}) {
-			$seen{$grna}++;
+		# print "cram_seq: $cram_seq\n";
+		my $matching_lib_seq = $lib_seqs{$cram_seq};
+		if ($matching_lib_seq) {
+			foreach my $grna (@{$lib->{$matching_lib_seq}->{'ids'}}) {
+				$seen{$grna}++;
+			}
 		}
 	}
 	close $PROC;
@@ -201,24 +230,27 @@ sub option_builder {
 	my %opts = ();
 
 	my $result = &GetOptions (
-		'h|help' => \$opts{'h'},
-		'i|dir=s' => \$opts{'i'},
-		'p|plas=s' => \$opts{'p'},
-		'o|output=s' => \$opts{'o'},
-		'l|library=s' => \$opts{'l'},
- 		't|trim=s' => \$opts{'t'},
-		'r|ref=s' => \$opts{'r'},
-                'v|version'   => \$opts{'v'});
+		'h|help'                => \$opts{'h'},
+		'i|input=s'             => \$opts{'i'},
+		'p|plasmid=s'           => \$opts{'p'},
+		'o|output=s'            => \$opts{'o'},
+		'l|library=s'           => \$opts{'l'},
+		't|trim=i'              => \$opts{'t'},
+		'rc|reverse-complement' => \$opts{'rc'},
+		'r|ref=s'               => \$opts{'r'},
+		'v|version'             => \$opts{'v'}
+	);
 
-    if ($opts{'v'}) {
-      print "Version: $VERSION\n";
-      exit 0;
-    }
+	if ($opts{'v'}) {
+		print "Version: $VERSION\n";
+		exit 0;
+	}
 
-   	pod2usage() if($opts{'h'});
-	pod2usage(1) if(!$opts{'o'});
-	pod2usage(1) if(!$opts{'r'});
-	pod2usage(q{(-i), (-l) and (-o) must be defined}) unless($opts{'i'}&&$opts{'l'}&&$opts{'o'});
+	pod2usage() if($opts{'h'});
+	pod2usage(-message => "Required argument '-i | --input' is missing.", -exitval => 1) if(!$opts{'i'});
+	pod2usage(-message => "Required argument '-l | --library' is missing.", -exitval => 1) if(!$opts{'l'});
+	pod2usage(-message => "Required argument '-o | --output' is missing.", -exitval => 1) if(!$opts{'o'});
+	pod2usage(-message => "Required argument '-r | --ref' is missing.", -exitval => 1)  if(!$opts{'r'});
 
 	return \%opts;
 }
@@ -235,18 +267,20 @@ crisprReadCounts.pl [-h] -i /your/input/file.cram -l /your/library/file -p /plas
 
   General Options:
 
-    --help      (-h)  Brief documentation
+    --help                  (-h)   Brief documentation
 
-    --dir       (-i)  Input sample cram file
+    --dir                   (-i)   Input sample cram file
 
-    --plas      (-p)  Plasmid count tsv file
+    --plas                  (-p)   Plasmid count tsv file
 
-    --library   (-l)  Library csv file
+    --library               (-l)   Library csv file
 
-    --output    (-o)  output file for read counts
+    --output                (-o)   output file for read counts
 
-    --ref       (-r)  genome reference fa file
+    --ref                   (-r)   genome reference fa file
 
-    --trim      (-t)  Remove N bases of leading sequence
+    --trim                  (-t)   Remove N bases of leading sequence
+
+    --reverse-complement    (-rc)  Reverse complementing reads when mapping to guide sequences 
 
 =cut


### PR DESCRIPTION
Changes are to address the following requests:

1. Allow trimming of reads where guide is at the start of the read and read length > guide length
Study 5647 (primer A only) the read length is 50bp and the guide length is 20bp (highlighted).  This won’t get trimmed to the guide length (lines 184-6) as trim will be set to 0.
 
Example:
GCTGAAGCGGCCAGCGAGGG GTTTAAGAGCTAAGCTGGAAACAGCATAGC
 
2. Allow reverse complementing of reads where reads are unmapped (i.e. don’t have flag 16 in the CRAM)
Study 5647 reads are unmapped (Kim, correct me if I’m wrong) so won’t have the right flag (16) to be reverse complemented (lines 179-181).  Also, looks like the trimming gets done after the reverse complementing.  For 5647 it would make life easier if the trimming was done before the reverse complementing as the trimming value could then be constant for all samples.

The commit was also tested on our CI and there's no change in results.